### PR TITLE
pillar: Adopt pillar to use native QEMU CPU pinning options.

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -328,8 +328,12 @@ func (s *ociSpec) UpdateFromDomain(dom *types.DomainConfig, status *types.Domain
 		s.Linux.Resources.Memory.Limit = &m
 		s.Linux.Resources.CPU.Period = &p
 		s.Linux.Resources.CPU.Quota = &q
-		if status.VmConfig.CPUs != "" {
-			s.Linux.Resources.CPU.Cpus = status.VmConfig.CPUs
+		if len(status.VmConfig.CPUs) != 0 {
+			cpusAsString := make([]string, len(status.VmConfig.CPUs))
+			for i, cpu := range status.VmConfig.CPUs {
+				cpusAsString[i] = fmt.Sprintf("%d", cpu)
+			}
+			s.Linux.Resources.CPU.Cpus = strings.Join(cpusAsString, ",")
 		}
 
 		s.Linux.CgroupsPath = fmt.Sprintf("/%s/%s", ctrdServicesNamespace, dom.GetTaskName())

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -641,6 +641,20 @@ func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig
 		"-readconfig", file.Name(),
 		"-pidfile", kvmStateDir+domainName+"/pid")
 
+	// Add CPUs affinity as a parameter to qemu.
+	// It's not supported to be configured in the .ini file so we need to add it here.
+	// The arguments are in the format of: -object thread-context,id=tc1,cpu-affinity=0-1,cpu-affinity=6-7
+	// The thread-context object is introduced in qemu 7.2
+	if config.CPUsPinned {
+		// Create the thread-context object string
+		threadContext := "thread-context,id=tc1"
+		for _, cpu := range status.CPUs {
+			// Add the cpu-affinity arguments to the thread-context object
+			threadContext += fmt.Sprintf(",cpu-affinity=%d", cpu)
+		}
+		args = append(args, "-object", threadContext)
+	}
+
 	spec, err := ctx.setupSpec(&status, &config, status.OCIConfigDir)
 	if err != nil {
 		return logError("failed to load OCI spec for domain %s: %v", status.DomainName, err)

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -252,8 +252,12 @@ func (ctx xenContext) CreateDomConfig(domainName string, config types.DomainConf
 		maxCpus = vCpus
 	}
 	file.WriteString(fmt.Sprintf("maxvcpus = %d\n", maxCpus))
-	if config.CPUs != "" {
-		file.WriteString(fmt.Sprintf("cpus = \"%s\"\n", config.CPUs))
+	if len(config.CPUs) > 0 {
+		cpusString := make([]string, 0)
+		for _, curCpu := range config.CPUs {
+			cpusString = append(cpusString, strconv.Itoa(curCpu))
+		}
+		file.WriteString(fmt.Sprintf("cpus = \"%s\"\n", strings.Join(cpusString, ",")))
 	}
 	if config.DeviceTree != "" {
 		file.WriteString(fmt.Sprintf("device_tree = \"%s\"\n",

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -212,7 +212,7 @@ type VmConfig struct {
 	ExtraArgs  string // added to bootargs
 	BootLoader string // default ""
 	// For CPU pinning
-	CPUs string // default "", list of "1,2"
+	CPUs []int // default nil, list of [1,2]
 	// Needed for device passthru
 	DeviceTree string // default ""; sets device_tree
 	// Example: device_tree="guest-gpio.dtb"


### PR DESCRIPTION
Update pillar's handling of QEMU guests to take advantage of native CPU pinning options introduced in the newer version of QEMU (7.2). This eliminates the need for our custom patches to QEMU for CPU pinning.

Changes include:
- Refactoring CPU pinning to use integer slices instead of comma-separated strings.
- Updating QEMU command-line arguments to include native CPU pinning options.
- Ensuring compatibility with both KVM and Xen hypervisors.

This change allows us to leverage upstream QEMU improvements and simplifies the codebase by removing custom patches and complex string manipulations.

Tested with QEMU version 8.0.4.